### PR TITLE
Update intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ draft-post-quantum-signatures.xml
 lib
 report.xml
 venv/
+
+.vscode

--- a/draft-post-quantum-jose.md
+++ b/draft-post-quantum-jose.md
@@ -79,9 +79,15 @@ email = "Dieter.Bong@utimaco.com"
 
 .# Abstract
 
-This document describes several post quantum cryptography (PQC) based
-digital signature schemes and how those signature schemes may be
-exchanged in JSON.
+This document describes JSON and CBOR serializations for several
+post quantum cryptography (PQC) based suites.
+
+This document does not define any new cryptography,
+only seralizations of existing cryptographic systems.
+
+This document registers key types for JOSE and COSE.
+
+This document registers signature algorithms types for JOSE and COSE.
 
 
 {mainmatter}


### PR DESCRIPTION
Compare to https://datatracker.ietf.org/doc/html/rfc8812

Their abstract is very direct... I suggest we follow suite and avoid adding anything other that the `kty` and `alg` names to the abstract.