### PR TITLE
fix: add "stream" to "seriesInfo" block to prevent mmark error

### DIFF
--- a/draft-post-quantum-jose.md
+++ b/draft-post-quantum-jose.md
@@ -8,8 +8,9 @@ submissiontype = "IETF"
 keyword = [""]
 
 [seriesInfo]
-name = "Individual-Draft"
+name = "Internet-Draft"
 value = "draft-post-quantum-jose-latest"
+stream = "IETF"
 status = "informational"
 
 [[author]]


### PR DESCRIPTION
Prevents "Incomplete or empty [seriesInfo] in title block, resulting XML will fail to parse" error

FIX #13